### PR TITLE
Fix build error in icon.py

### DIFF
--- a/nefile/resources/icon.py
+++ b/nefile/resources/icon.py
@@ -1,7 +1,7 @@
 
 import self_documenting_struct as struct
 import os
-from Bitmap import BitmapInfoHeader
+from .bitmap import BitmapInfoHeader
 
 ## Reads an RT_GROUP_ICON resource.
 ## In the executable, the RT_GROUP_ICON resource itself 


### PR DESCRIPTION
I couldn't install nefile without changing the import in icon.py as in this PR.